### PR TITLE
16-Fails-to-parse-n-grams-when-reading-from-file-if-n-grams-contain-commas

### DIFF
--- a/src/NgramModel/NgramModel.class.st
+++ b/src/NgramModel/NgramModel.class.st
@@ -51,7 +51,7 @@ NgramModel class >> readCountsFromFile: aFileReference [
 	[stream atEnd] whileFalse: [ 
 		values := stream nextLine substrings: ','.
 		ngram := values first substrings asNgram.
-		count := values second asNumber.
+		count := values last asNumber.
 		counts add: ngram withOccurrences: count ].
 	
 	stream close.


### PR DESCRIPTION
intermediate fix for #16